### PR TITLE
Add multiselect field type

### DIFF
--- a/client/components/Fields/LabeledMultiSelect.jsx
+++ b/client/components/Fields/LabeledMultiSelect.jsx
@@ -1,0 +1,26 @@
+import React, { Component, PropTypes } from 'react';
+import { Multiselect } from 'auth0-extension-ui';
+
+class LabeledMultiSelect extends Component {
+
+  render() {
+    const { input, label } = this.props;
+    return (
+      <div className="form-group">
+        <label htmlFor={input.name} className="control-label col-xs-3">
+          {label}
+        </label>
+        <div className="col-xs-9">
+          <Multiselect {...this.props} />
+        </div>
+      </div>
+    );
+  }
+}
+
+LabeledMultiSelect.propTypes = {
+  input: PropTypes.object.isRequired,
+  label: PropTypes.string.isRequired
+};
+
+export default LabeledMultiSelect;

--- a/client/components/Users/UserForm.jsx
+++ b/client/components/Users/UserForm.jsx
@@ -4,6 +4,7 @@ import { InputText, InputCombo, Multiselect } from 'auth0-extension-ui';
 import { Button, Modal } from 'react-bootstrap';
 import { connect } from 'react-redux';
 import { reduxForm, Field, formValueSelector } from 'redux-form';
+import LabeledMultiSelect from '../Fields/LabeledMultiSelect';
 
 class AddUserForm extends Component {
   static propTypes = {
@@ -83,13 +84,37 @@ class AddUserForm extends Component {
     );
   }
 
-  getFieldComponent(componentName) {
+  getFieldComponent(field, component, additionalOptions) {
+    return (
+      <Field
+        name={field.property}
+        type={field.type}
+        label={field.label}
+        component={component}
+        {...additionalOptions}
+      />
+    );
+  }
+
+  getFieldByComponentName(field, componentName) {
     switch (componentName) {
       case 'InputText': {
-        return InputText;
+        const additionalOptions = {
+          options: field.options ? _.map(field.options, (i) => ({ value: i, text: i })) : null
+        };
+        return (this.getFieldComponent(field, InputText, additionalOptions));
       }
       case 'InputCombo': {
-        return InputCombo;
+        const additionalOptions = {
+          options: field.options ? _.map(field.options, (i) => ({ value: i, text: i })) : null
+        };
+        return (this.getFieldComponent(field, InputCombo, additionalOptions));
+      }
+      case 'Multiselect': {
+        const additionalOptions = {
+          loadOptions: (input, callback) => callback(null, { options: field.options ? _.map(field.options, (i) => ({ label: i, value: i })) : [], complete: true })
+        };
+        return (this.getFieldComponent(field, LabeledMultiSelect, additionalOptions));
       }
       default: {
         return InputText;
@@ -98,24 +123,7 @@ class AddUserForm extends Component {
   }
 
   renderCustomFields(customFields) {
-    if (customFields) {
-      return (
-        <div>
-          { _.map(customFields, (field) => ((
-            <Field
-              name={field.property}
-              type={field.type}
-              label={field.label}
-              component={this.getFieldComponent(field.component)}
-              options={field.options ? _.map(field.options, (i) => ({ value: i, text: i })) : null}
-            />
-          )
-          ))}
-        </div>
-      );
-    }
-
-    return null;
+    return _.map(customFields, field => ((this.getFieldByComponentName(field, field.component))));
   }
 
   render() {


### PR DESCRIPTION
Add support for MultiSelect fields by using the `Multiselect` component.

Updated field.
```
{
        "property":"app_metadata.applicationRoles",
        "type":"select",
        "options":roleHierarchy,
        "label":"Role(s)",
        "component":"Multiselect",
        "display": true,
        "searchListOrder": 4,
        "searchListSize": "25%"
      }
```