### PR TITLE
Default searchEngine option

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "async": "^1.5.2",
     "auth0": "^2.1.0",
-    "auth0-extension-express-tools": "1.1.6",
+    "auth0-extension-express-tools": "1.1.7",
     "auth0-extension-tools": "1.3.1",
     "auth0-extension-ui": "~1.1.6",
     "auth0-js": "^8.9.3",

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -172,6 +172,7 @@ export default (storage, scriptManager) => {
     scriptManager.execute('filter', filterContext)
       .then((filter) => {
         const searchEngine = filter && filter.searchEngine;
+        const defaultEngine = (config('AUTH0_RTA').replace('https://', '') === 'auth0.auth0.com') ? 'v2' : 'v3';
         const filterQuery = (filter && typeof filter.query !== 'undefined') ? filter.query : filter;
         const options = {
           sort,
@@ -180,7 +181,7 @@ export default (storage, scriptManager) => {
           page: req.query.page || 0,
           include_totals: true,
           fields: 'user_id,username,name,email,identities,picture,last_login,logins_count,multifactor,blocked,app_metadata,user_metadata',
-          search_engine: searchEngine || config('SEARCH_ENGINE') || 'v3'
+          search_engine: searchEngine || (config('SEARCH_ENGINE') !== 'default' && config('SEARCH_ENGINE')) || defaultEngine
         };
 
         return req.auth0.users.getAll(options);

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -172,7 +172,7 @@ export default (storage, scriptManager) => {
     scriptManager.execute('filter', filterContext)
       .then((filter) => {
         const searchEngine = filter && filter.searchEngine;
-        const defaultEngine = (config('AUTH0_RTA').replace('https://', '') === 'auth0.auth0.com') ? 'v2' : 'v3';
+        const defaultEngine = (config('AUTH0_RTA').replace('https://', '') !== 'auth0.auth0.com') ? 'v2' : 'v3';
         const filterQuery = (filter && typeof filter.query !== 'undefined') ? filter.query : filter;
         const options = {
           sort,

--- a/webtask.json
+++ b/webtask.json
@@ -54,8 +54,12 @@
       "description": "Engine for searching users",
       "type": "select",
       "allowMultiple": false,
-      "default": "v3",
+      "default": "default",
       "options": [
+        {
+          "value": "default",
+          "text": "Default"
+        },
         {
           "value": "v2",
           "text": "v2"


### PR DESCRIPTION
Default options are: v2 for appliances, v3 for cloud.
`searchEngine` still can be changed in extension settings or through `filter` hook.